### PR TITLE
feat: debloat package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,8 @@
   "dependencies": {
     "@babel/core": "^7.13.15",
     "@babel/preset-env": "^7.13.15",
-    "@babel/preset-react": "^7.13.13",
     "browserify": "16.2.0",
     "chai": "4.2.0",
-    "coveralls": "3.0.2",
     "css-mqpacker": "6.0.2",
     "fancy-log": "^1.3.2",
     "gulp-autoprefixer": "5.0.0",


### PR DESCRIPTION
Hi,

Thanks for developing this good project, which provides high-coverage tests.

I'm doing dynamic analysis on npm packages, and your project is one of my samples.

Through our dynamic analysis by running the test suites, we find that 2 of the runtime dependencies are installed, however, they are not used during test runtime. We removed these dependencies from package.json, and installed the remaining dependencies, the tests all passed.

Would you consider creating a slim version of the package.json, which can help reduce the corresponding maintenance costs and security risks in production?
